### PR TITLE
feat(v3 collections): [sc-2399] Add _meta block number check to vault holdings request for fallback checks

### DIFF
--- a/packages/subgraph/src/querySubgraph.ts
+++ b/packages/subgraph/src/querySubgraph.ts
@@ -6,6 +6,146 @@ import type { QueryBase } from './createQuery';
 type Fetch = typeof fetch;
 const globalFetch = typeof fetch === 'undefined' ? undefined : fetch;
 
+const formatQuery = ({
+  query,
+  requiredBlock,
+  variables,
+}: {
+  query: any;
+  variables: Record<string, any> | undefined;
+  requiredBlock: number | undefined;
+}) => {
+  if (typeof query !== 'string') {
+    query = query.toString();
+  }
+  if (variables) {
+    query = interpolateQuery(query, variables);
+  }
+  if (requiredBlock) {
+    query = query.replace(/\{/, `{\n  _meta { block { number } }`);
+  }
+  return query;
+};
+
+const handleErrors = (errors: any) => {
+  // If there was an error with the query, we'll receive an array of errors
+  if (errors?.[0]?.message) {
+    throw new UnknownError(errors[0].message);
+  }
+  // Potentially a more generic error (like the endpoint was down)
+  if (errors?.message) {
+    throw new UnknownError(errors.message);
+  }
+};
+
+const doSubgraphQuery = async ({
+  query,
+  url,
+  fetch,
+}: {
+  url: string;
+  query: string;
+  fetch: Fetch | undefined;
+}) => {
+  const { data, errors } = await sendQuery<{
+    errors: { message: string }[] & { message: string };
+    data: any;
+  }>({
+    url,
+    cache: 'no-cache',
+    fetch,
+    headers: { 'Content-Type': 'application/json' },
+    query: { query },
+    method: 'POST',
+  });
+
+  handleErrors(errors);
+
+  return data;
+};
+
+const queryWhileSubgraphBehind = async ({
+  query,
+  requiredBlock,
+  url,
+  fetch,
+}: {
+  url: string;
+  query: string;
+  requiredBlock: number | undefined;
+  fetch: Fetch | undefined;
+}) => {
+  // If we're given a required block, we want to add it to the query string, and check it
+  // if the subgraph is behind, we'll wait and try again (up to 3 times)
+  let blockChecks = 0;
+
+  do {
+    const data = await doSubgraphQuery({ query, url, fetch });
+
+    // If we're not checking for a specific block, we can stop here
+    if (!requiredBlock) {
+      return data;
+    }
+    // If the subgraph is up to date, we can stop here
+    if (Number(data?._meta?.block?.number) >= requiredBlock) {
+      delete data._meta;
+      return data;
+    }
+    // If we've tried 3 times and the subgraph is still behind, throw an error
+    if (blockChecks >= 2) {
+      throw new Error(
+        `Subgraph at ${url} is not up to date. Expected block ${requiredBlock}, got ${data?._meta?.block?.number}`
+      );
+    }
+    // Wait 5s and try again
+    blockChecks += 1;
+    await new Promise((res) => setTimeout(res, 5000));
+  } while (blockChecks < 3);
+
+  throw new Error(`Subgraph at ${url} is not up to date`);
+};
+
+const queryUrls = async ({
+  baseUrl,
+  query,
+  requiredBlock,
+  fetch,
+}: {
+  baseUrl: string | string[];
+  query: string;
+  requiredBlock: number | undefined;
+  fetch: Fetch | undefined;
+}) => {
+  // We can be passed a single url or an array of urls
+  // If we have an array, we'll try them in order until we get a successful response
+  const urls = [baseUrl].flat();
+
+  while (urls.length) {
+    try {
+      const url = urls.shift();
+      // Ignore empty urls (baseUrl could be undefined, or an array could've been built with missing content)
+      if (url == null) {
+        continue;
+      }
+
+      const data = await queryWhileSubgraphBehind({
+        query,
+        requiredBlock,
+        url,
+        fetch,
+      });
+
+      return data;
+    } catch (e) {
+      // If there's been an error, we'll try the next url
+      // if we've exhausted all urls, throw the most recent error
+      if (!urls.length) {
+        throw e;
+      }
+    }
+  }
+};
+
 /** Sends a request to the subgraph
  * Uses the fetch api under the hood so if running in node you'll need to polyfill global.fetch
  */
@@ -21,6 +161,9 @@ async function querySubgraph<Q extends GraphQueryString<any, any>>(args: {
   variables?: Q['__v'];
   /** The fetch api to use, if you are using a ponyfill, you can manually pass it in here */
   fetch?: Fetch;
+  /** A block number that the subgraph must be up to in order to be considered up to date.
+   * If the subgraph block is less than this number, it will wait and re-attempt 3 times */
+  requiredBlock?: number;
 }): Promise<Q['__r']>;
 async function querySubgraph<Q extends QueryBase<any, any>>(args: {
   /** The subgraph url */
@@ -29,6 +172,9 @@ async function querySubgraph<Q extends QueryBase<any, any>>(args: {
   query: Q;
   /** The fetch api to use, if you are using a ponyfill, you can manually pass it in here */
   fetch?: Fetch;
+  /** A block number that the subgraph must be up to in order to be considered up to date.
+   * If the subgraph block is less than this number, it will wait and re-attempt 3 times */
+  requiredBlock?: number;
 }): Promise<Q['__r']>;
 async function querySubgraph(args: {
   /** The subgraph url */
@@ -36,62 +182,27 @@ async function querySubgraph(args: {
   query: string;
   variables?: Record<string, any>;
   fetch?: Fetch;
+  requiredBlock?: number;
 }): Promise<any>;
 async function querySubgraph({
   url: baseUrl,
   query,
   variables,
   fetch = globalFetch,
+  requiredBlock,
 }: {
   url: string | string[];
   query: any;
   variables?: Record<string, any>;
   fetch?: Fetch;
+  requiredBlock?: number;
 }) {
-  if (typeof query !== 'string') {
-    query = query.toString();
-  }
-  if (variables) {
-    query = interpolateQuery(query, variables);
-  }
-
-  // Override the default api key with a custom one if set
-  const urls = [baseUrl].flat();
-
-  while (urls.length) {
-    try {
-      const url = urls.shift();
-      if (url == null) {
-        continue;
-      }
-
-      const { data, errors } = await sendQuery<{
-        errors: { message: string }[] & { message: string };
-        data: any;
-      }>({
-        url,
-        cache: 'no-cache',
-        fetch,
-        headers: { 'Content-Type': 'application/json' },
-        query: { query },
-        method: 'POST',
-      });
-
-      // If there was an error with the query, we'll receive an array of errors
-      if (errors?.[0]?.message) {
-        throw new UnknownError(errors[0].message);
-      }
-      if (errors?.message) {
-        throw new UnknownError(errors.message);
-      }
-
-      return data;
-    } catch (e) {
-      if (!urls.length) {
-        throw e;
-      }
-    }
-  }
+  return queryUrls({
+    baseUrl,
+    query: formatQuery({ query, requiredBlock, variables }),
+    requiredBlock,
+    fetch,
+  });
 }
 
 export default querySubgraph;


### PR DESCRIPTION
Story details: https://app.shortcut.com/nftx/story/2399

    you can now pass a requiredBlock to querySubgraph, if provided, it will check the block number of the subgraph response
    if the subgraph is behind the required block, it will wait and make 2 more attempts to get the latest block
    if the subgraph is still behind, an error will be thrown
    ths requiredBlock parameter is optional and if omitted, it will work exactly as before
    currently not being used within nftx.js methods internally but this provision means it can be added in the future