### PR TITLE
Feat/bypass liquidity check

### DIFF
--- a/packages/core/src/prices/priceVaultSwap.ts
+++ b/packages/core/src/prices/priceVaultSwap.ts
@@ -103,6 +103,7 @@ export const makePriceVaultSwap =
     holdings: allHoldings,
     vault,
     bypassIndexedPrice,
+    bypassLiquidityCheck,
   }: {
     network: number;
     provider: Provider;
@@ -114,6 +115,7 @@ export const makePriceVaultSwap =
     buyTokenIds: TokenIds;
     holdings: Pick<VaultHolding, 'dateAdded' | 'tokenId' | 'quantity'>[];
     bypassIndexedPrice?: boolean;
+    bypassLiquidityCheck?: boolean;
   }) => {
     const now = Math.floor(Date.now() / 1000);
     const totalIn = getTotalTokenIds(sellTokenIds);
@@ -153,6 +155,7 @@ export const makePriceVaultSwap =
             sellTokenIds,
             userAddress: '0x',
             vault,
+            bypassLiquidityCheck,
           });
         }
       }

--- a/packages/core/src/prices/quoteVaultBuy.ts
+++ b/packages/core/src/prices/quoteVaultBuy.ts
@@ -105,6 +105,7 @@ export const makeQuoteVaultBuy =
     vault,
     holdings: allHoldings,
     slippagePercentage,
+    bypassLiquidityCheck,
   }: {
     vault: Pick<Vault, 'fees' | 'id' | 'vaultId' | 'is1155'>;
     tokenIds: TokenIds;
@@ -113,6 +114,7 @@ export const makeQuoteVaultBuy =
     provider: Provider;
     holdings: Pick<VaultHolding, 'dateAdded' | 'tokenId'>[];
     slippagePercentage?: number;
+    bypassLiquidityCheck?: boolean;
   }) => {
     const totalTokenIds = getTotalTokenIds(tokenIds);
     const buyAmount = parseEther(`${totalTokenIds}`);
@@ -143,6 +145,7 @@ export const makeQuoteVaultBuy =
       sellToken: 'WETH',
       userAddress: getChainConstant(MARKETPLACE_ZAP, network),
       slippagePercentage,
+      throwOnError: !bypassLiquidityCheck,
     });
 
     const items = await Promise.all(

--- a/packages/core/src/prices/quoteVaultMint.ts
+++ b/packages/core/src/prices/quoteVaultMint.ts
@@ -23,6 +23,7 @@ const quoteVaultMint = async ({
   userAddress,
   vault,
   slippagePercentage,
+  bypassLiquidityCheck,
 }: {
   network: number;
   tokenIds: TokenIds;
@@ -30,6 +31,7 @@ const quoteVaultMint = async ({
   vault: Pick<Vault, 'id' | 'vaultId' | 'fees' | 'is1155' | 'asset'>;
   provider: Provider;
   slippagePercentage?: number;
+  bypassLiquidityCheck?: boolean;
 }) => {
   const { feePrice, items, premiumPrice, price, vTokenPrice } =
     await quoteVaultSell({
@@ -39,6 +41,7 @@ const quoteVaultMint = async ({
       userAddress,
       vault,
       slippagePercentage,
+      bypassLiquidityCheck,
     });
 
   const tokenIdsIn = getUniqueTokenIds(tokenIds);

--- a/packages/core/src/prices/quoteVaultRedeem.ts
+++ b/packages/core/src/prices/quoteVaultRedeem.ts
@@ -28,6 +28,7 @@ const quoteVaultRedeem = async ({
   userAddress,
   vault,
   slippagePercentage,
+  bypassLiquidityCheck,
 }: {
   network: number;
   provider: Provider;
@@ -36,6 +37,7 @@ const quoteVaultRedeem = async ({
   tokenIds: TokenIds;
   holdings: VaultHolding[];
   slippagePercentage?: number;
+  bypassLiquidityCheck?: boolean;
 }) => {
   const standard = vault.is1155 ? 'ERC1155' : 'ERC721';
   const totalTokenIds = getTotalTokenIds(tokenIds);
@@ -62,6 +64,7 @@ const quoteVaultRedeem = async ({
     vault,
     network,
     slippagePercentage,
+    bypassLiquidityCheck,
   });
 
   const value = increaseByPercentage(

--- a/packages/core/src/prices/quoteVaultSell.ts
+++ b/packages/core/src/prices/quoteVaultSell.ts
@@ -39,6 +39,7 @@ export const makeQuoteVaultSell =
     userAddress,
     vault,
     slippagePercentage,
+    bypassLiquidityCheck,
   }: {
     vault: Pick<Vault, 'id' | 'fees' | 'asset' | 'vaultId' | 'is1155'>;
     network: number;
@@ -46,6 +47,7 @@ export const makeQuoteVaultSell =
     userAddress: Address;
     provider: Provider;
     slippagePercentage?: number;
+    bypassLiquidityCheck?: boolean;
   }) => {
     const totalTokenIds = getTotalTokenIds(tokenIds);
     const sellAmount = parseEther(`${totalTokenIds}`);
@@ -74,6 +76,7 @@ export const makeQuoteVaultSell =
       network,
       userAddress: getChainConstant(MARKETPLACE_ZAP, network),
       slippagePercentage,
+      throwOnError: !bypassLiquidityCheck,
     });
     const vTokenPricePerItem = (vTokenPrice * WeiPerEther) / sellAmount;
 

--- a/packages/core/src/prices/quoteVaultSwap.ts
+++ b/packages/core/src/prices/quoteVaultSwap.ts
@@ -53,6 +53,7 @@ export const makeQuoteVaultSwap =
     buyTokenIds: TokenIds;
     holdings: Pick<VaultHolding, 'dateAdded' | 'tokenId'>[];
     slippagePercentage?: number;
+    bypassLiquidityCheck?: boolean;
   }) => {
     const tokenIdsIn = getUniqueTokenIds(sellTokenIds);
     const amountsIn = getTokenIdAmounts(sellTokenIds);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -21,3 +21,19 @@ export const mapObj = <T extends Record<string, any>>(
 ): any => {
   return reduceObj(obj, (acc, key, value) => [...acc, fn(key, value)]);
 };
+
+/**
+ * wraps a promise and returns a tuple of [error, result]
+ * @param p Promise
+ * @returns [error, result]
+ */
+export const t = <T>(p: Promise<T>): Promise<[any, T]> => {
+  return p.then(
+    (result) => {
+      return [undefined, result] as [any, T];
+    },
+    (err) => {
+      return [err, undefined] as [any, T];
+    }
+  );
+};

--- a/packages/trade/src/price/fetchAmmQuote.ts
+++ b/packages/trade/src/price/fetchAmmQuote.ts
@@ -6,7 +6,7 @@ import type {
   QuoteToken,
 } from '@nftx/types';
 import config from '@nftx/config';
-import { NFTX_ROUTER, WeiPerEther } from '@nftx/constants';
+import { NFTX_ROUTER, WeiPerEther, Zero } from '@nftx/constants';
 import { getChainConstant } from '@nftx/utils';
 import parseQuoteToken from './parseQuoteToken';
 import {
@@ -17,15 +17,31 @@ import {
 import { NftxQuote } from './types';
 import ammQuoteToPrice from './ammQuoteToPrice';
 
+const fallbackQuote = {
+  approveContracts: [],
+  estimatedGas: Zero,
+  feePrice: Zero,
+  items: [],
+  methodParameters: undefined as any,
+  premiumPrice: Zero,
+  price: Zero,
+  vTokenPrice: Zero,
+  type: 'erc20' as const,
+};
+
 const fetchAmmQuote = async (args: {
   network?: number;
   buyToken: QuoteToken;
   buyAmount?: BigIntish;
   sellToken: QuoteToken;
   sellAmount?: BigIntish;
+  /** The amount of slippage (in decimal terms) you're willing to accept - defaults to 1% */
   slippagePercentage?: number;
   userAddress?: Address;
+  /** Optionally use permit2 to approve spending tokens */
   permit2?: Permit2Quote;
+  /** If unable to get a quote, this option determines whether to throw an error, or just return a 0 price object. Defaults to true */
+  throwOnError?: boolean;
 }): Promise<MarketplaceQuote> => {
   const {
     network = config.network,
@@ -34,95 +50,109 @@ const fetchAmmQuote = async (args: {
     slippagePercentage = 0.01,
     userAddress,
     permit2,
+    throwOnError = true,
   } = args;
-  const sellToken = parseQuoteToken(args.sellToken, network);
-  const buyToken = parseQuoteToken(args.buyToken, network);
 
-  const baseUrl = getChainConstant(config.urls.NFTX_ROUTER_URL, network, null);
+  try {
+    const sellToken = parseQuoteToken(args.sellToken, network);
+    const buyToken = parseQuoteToken(args.buyToken, network);
 
-  ValidationError.validate({
-    sellToken: () => !!sellToken || 'Required',
-    network: () => {
-      if (!network) {
-        return 'Required';
-      }
-      if (!baseUrl) {
-        return 'Not currently supported for NFTX Router';
-      }
-    },
-    buyToken: () => !!buyToken || 'Required',
-  });
-
-  const searchParams = new URLSearchParams();
-  searchParams.append('tokenInAddress', sellToken);
-  searchParams.append('tokenInChainId', `${network}`);
-  searchParams.append('tokenOutAddress', buyToken);
-  searchParams.append('tokenOutChainId', `${network}`);
-
-  if (buyAmount) {
-    searchParams.append('amount', BigInt(buyAmount).toString());
-    searchParams.append('type', 'exactOut');
-  } else if (sellAmount) {
-    searchParams.append('amount', BigInt(sellAmount).toString());
-    searchParams.append('type', 'exactIn');
-  } else {
-    // Default to just buying 1
-    searchParams.append('buyAmount', WeiPerEther.toString());
-    searchParams.append('type', 'exactOut');
-  }
-
-  if (userAddress) {
-    searchParams.append('recipient', userAddress);
-    searchParams.append('deadline', '300');
-    searchParams.append('enableUniversalRouter', 'true');
-    searchParams.append(
-      'slippageTolerance',
-      `${(slippagePercentage ?? 0.01) * 100}`
+    const baseUrl = getChainConstant(
+      config.urls.NFTX_ROUTER_URL,
+      network,
+      null
     );
-    searchParams.append('intent', 'swap');
-  } else {
-    searchParams.append('intent', 'quote');
+
+    ValidationError.validate({
+      sellToken: () => !!sellToken || 'Required',
+      network: () => {
+        if (!network) {
+          return 'Required';
+        }
+        if (!baseUrl) {
+          return 'Not currently supported for NFTX Router';
+        }
+      },
+      buyToken: () => !!buyToken || 'Required',
+    });
+
+    const searchParams = new URLSearchParams();
+    searchParams.append('tokenInAddress', sellToken);
+    searchParams.append('tokenInChainId', `${network}`);
+    searchParams.append('tokenOutAddress', buyToken);
+    searchParams.append('tokenOutChainId', `${network}`);
+
+    if (buyAmount) {
+      searchParams.append('amount', BigInt(buyAmount).toString());
+      searchParams.append('type', 'exactOut');
+    } else if (sellAmount) {
+      searchParams.append('amount', BigInt(sellAmount).toString());
+      searchParams.append('type', 'exactIn');
+    } else {
+      // Default to just buying 1
+      searchParams.append('buyAmount', WeiPerEther.toString());
+      searchParams.append('type', 'exactOut');
+    }
+
+    if (userAddress) {
+      searchParams.append('recipient', userAddress);
+      searchParams.append('deadline', '300');
+      searchParams.append('enableUniversalRouter', 'true');
+      searchParams.append(
+        'slippageTolerance',
+        `${(slippagePercentage ?? 0.01) * 100}`
+      );
+      searchParams.append('intent', 'swap');
+    } else {
+      searchParams.append('intent', 'quote');
+    }
+
+    searchParams.append('protocols', 'v3');
+
+    if (permit2) {
+      searchParams.append('permitSignature', permit2.signature);
+      searchParams.append('permitAmount', permit2.amount.toString());
+      searchParams.append('permitExpiration', permit2.expiration.toString());
+      searchParams.append('permitSigDeadline', permit2.sigDeadline.toString());
+      searchParams.append('permitNonce', permit2.nonce.toString());
+    }
+
+    const query = searchParams.toString();
+
+    const url = `${baseUrl}?${query}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      const json = await response.json();
+      throw new QuoteFailedError(json);
+    }
+
+    const data: NftxQuote = await response.json();
+
+    if (userAddress && !data?.methodParameters) {
+      throw new QuoteSlippageError();
+    }
+    if (userAddress && config.debug) {
+      console.debug(data);
+    }
+
+    if (data?.methodParameters?.to) {
+      // We need to override the to property as it's pointing to the Uniswap router instead of our own
+      data.methodParameters.to = getChainConstant(NFTX_ROUTER, network);
+    }
+
+    return ammQuoteToPrice({
+      ...data,
+      network,
+      sellToken,
+      buyToken,
+    });
+  } catch (e) {
+    if (!throwOnError) {
+      return fallbackQuote;
+    }
+
+    throw e;
   }
-
-  searchParams.append('protocols', 'v3');
-
-  if (permit2) {
-    searchParams.append('permitSignature', permit2.signature);
-    searchParams.append('permitAmount', permit2.amount.toString());
-    searchParams.append('permitExpiration', permit2.expiration.toString());
-    searchParams.append('permitSigDeadline', permit2.sigDeadline.toString());
-    searchParams.append('permitNonce', permit2.nonce.toString());
-  }
-
-  const query = searchParams.toString();
-
-  const url = `${baseUrl}?${query}`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    const json = await response.json();
-    throw new QuoteFailedError(json);
-  }
-
-  const data: NftxQuote = await response.json();
-
-  if (userAddress && !data?.methodParameters) {
-    throw new QuoteSlippageError();
-  }
-  if (userAddress && config.debug) {
-    console.debug(data);
-  }
-
-  if (data?.methodParameters?.to) {
-    // We need to override the to property as it's pointing to the Uniswap router instead of our own
-    data.methodParameters.to = getChainConstant(NFTX_ROUTER, network);
-  }
-
-  return ammQuoteToPrice({
-    ...data,
-    network,
-    sellToken,
-    buyToken,
-  });
 };
 
 export default fetchAmmQuote;


### PR DESCRIPTION
For some background, we currently have an issue with unstaking inventory where if there's no liquidity in the vault, we're unable to fetch a quote, but we need the quote data to actually handle the unstake (and determine if there are any fees or premiums to pay).
Unstaking inventory shouldn't care about whether there's enough liquidity or not, but all of the remaining quote logic that we actually need is too engrained in the quote system. The aim of this PR is to make it so we can grab all the quote data while specifying that we don't care whether there's actually enough liquidity for the buy/sell/swap action itself.

Commits:

    feat(@nftx/trade): add option to soft fail out of amm quotes
    
    By default if an amm quote fails or is invalid, it will throw an error
    This commit adds the option to instead simply return an empty quote object

    feat(@nftx/core): bypass liquidity check for vault buy/sell/swap
    
    This commit adds a bypassLiquidityCheck parameter to the price and quote methods.
    This allows us to get a quote for a trade without checking if there is enough liquidity,
    and means we can still calculate premiums and vault fees for a trade.