### PR TITLE
fix: deprecate reservoir

### DIFF
--- a/packages/core/src/vaults/fetchVaults/fetchVaults.ts
+++ b/packages/core/src/vaults/fetchVaults/fetchVaults.ts
@@ -90,8 +90,6 @@ export const makeFetchVaults =
       vaultIds: vaultData.map((v) => v.vaultId),
     });
 
-    const collections: Record<string, Collection> = {};
-
     const vaultPromises =
       vaultData.map(async (x) => {
         const merkleData = {
@@ -110,20 +108,11 @@ export const makeFetchVaults =
           vaultAddress: x.id as Address,
         });
 
-        let collection = collections[x.asset.id];
-        if (!collection) {
-          collection = collections[x.asset.id] = await fetchCollection({
-            network,
-            assetAddress: x.asset.id as Address,
-          });
-        }
-
         const vault = transformVault({
           globalFees,
           vault: x,
           merkleReference,
           vTokenToEth,
-          collection,
         });
 
         const holdings = allHoldings.filter((h) => h.vaultId === x.vaultId);

--- a/packages/core/src/vaults/fetchVaults/transformVault.ts
+++ b/packages/core/src/vaults/fetchVaults/transformVault.ts
@@ -42,13 +42,11 @@ const transformVault = ({
   globalFees,
   merkleReference,
   vTokenToEth,
-  collection,
 }: {
   vault: Response['vaults'][0];
   globalFees: Response['globals'][0]['fees'];
   merkleReference?: string;
   vTokenToEth: bigint;
-  collection: { slug: string };
 }) => {
   const state: VaultState = getVaultState(x);
 
@@ -68,7 +66,7 @@ const transformVault = ({
     id: x.id as Address,
     vaultId: `${x.vaultId}`,
     slug: `${x.token.symbol}-${x.vaultId}`.toLowerCase(),
-    collectionSlug: (collection?.slug || x.asset.symbol).toLowerCase(),
+    collectionSlug: x.asset.symbol.toLowerCase(),
     state,
     asset: {
       ...x.asset,

--- a/packages/utils/src/web2/queryReservoir.ts
+++ b/packages/utils/src/web2/queryReservoir.ts
@@ -1,33 +1,12 @@
-import config from '@nftx/config';
-import { getChainConstant } from '../web3';
 import query from './query';
-import { RESERVOIR_URL } from '@nftx/constants';
 
 type Args = Omit<Parameters<typeof query>[0], 'url'> & {
   network?: number;
   path: string;
 };
 
-const queryReservoir = <T>({
-  path,
-  network = config.network,
-  ...rest
-}: Args) => {
-  const base = getChainConstant(RESERVOIR_URL, network);
-  const uri = new URL(path, base);
-  const headers: Record<string, string> = { accept: '*/*' };
-  const apiKey = getChainConstant(config.keys.RESERVOIR, network, null);
-  if (apiKey) {
-    headers['x-api-key'] = apiKey;
-  } else {
-    console.warn('No reservoir api key provided');
-  }
-
-  return query<T>({
-    url: uri.toString(),
-    headers,
-    ...rest,
-  });
+const queryReservoir = <T>(_args: Args): Promise<T> => {
+  throw new Error("Reservoir has been decommissioned. Please use an alternative provider.")
 };
 
 export default queryReservoir;


### PR DESCRIPTION
reservoir.tools has been decomissioned and is no longer accessible as certain parts of nftx.js are built around reservoir (specifically for asset and collection data), they will now fail currently you will just get a "failed to fetch error" with no real explanation this commit throws a meaningful error instead
it also removes the reliance on reservoir in the fetchVaults method - we don't want the entire process to fail because we're unable to fetch some optional field data whether or not we look to reimplement all of the methods that will be failing is not yet decided, the following methods are directly affected:
- fetchAssets
- streamAssets
- fetchAssetsFromReservoir
- fetchCollection
- fetchUserAssets